### PR TITLE
Isochronous transfer fix follow-up

### DIFF
--- a/src/bus.rs
+++ b/src/bus.rs
@@ -725,8 +725,6 @@ impl<USB: UsbPeripheral> usb_device::bus::UsbBus for UsbBus<USB> {
                     modify_reg!(endpoint_in, ep_regs, DIEPCTL, SNAK: 1, EPDIS: 1);
                     while read_reg!(endpoint_in, ep_regs, DIEPINT, EPDISD) == 0 {}
                     modify_reg!(endpoint_in, ep_regs, DIEPINT, EPDISD: 1);
-                    assert!(read_reg!(endpoint_in, ep_regs, DIEPCTL, EPENA) == 0);
-                    assert!(read_reg!(endpoint_in, ep_regs, DIEPCTL, EPDIS) == 0);
 
                     // Flush the TX FIFO
                     modify_reg!(otg_global, regs.global(), GRSTCTL, TXFNUM: epnum as u32, TXFFLSH: 1);

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -511,7 +511,8 @@ impl<USB: UsbPeripheral> usb_device::bus::UsbBus for UsbBus<USB> {
             write_reg!(otg_global, regs.global(), GINTMSK,
                 USBRST: 1, ENUMDNEM: 1,
                 USBSUSPM: 1, WUIM: 1,
-                IEPINT: 1, RXFLVLM: 1
+                IEPINT: 1, RXFLVLM: 1,
+                IISOIXFRM: 1
             );
 
             // clear pending interrupts
@@ -598,7 +599,7 @@ impl<USB: UsbPeripheral> usb_device::bus::UsbBus for UsbBus<USB> {
 
             let core_id = read_reg!(otg_global, regs.global(), CID);
 
-            let (wakeup, suspend, enum_done, reset, iep, rxflvl) = read_reg!(
+            let (wakeup, suspend, enum_done, reset, iep, rxflvl, iisoixfr) = read_reg!(
                 otg_global,
                 regs.global(),
                 GINTSTS,
@@ -607,7 +608,8 @@ impl<USB: UsbPeripheral> usb_device::bus::UsbBus for UsbBus<USB> {
                 ENUMDNE,
                 USBRST,
                 IEPINT,
-                RXFLVL
+                RXFLVL,
+                IISOIXFR
             );
 
             if reset != 0 {
@@ -676,6 +678,63 @@ impl<USB: UsbPeripheral> usb_device::bus::UsbBus for UsbBus<USB> {
                 write_reg!(otg_global, regs.global(), GINTSTS, USBSUSP: 1);
 
                 PollResult::Suspend
+            } else if iisoixfr != 0 {
+                use crate::ral::endpoint_in;
+
+                // Incomplete isochronous IN transfer; see
+                // RM0383 Rev 3 pp797 "Incomplete isochronous IN data transfers"
+                write_reg!(otg_global, regs.global(), GINTSTS, IISOIXFR: 1);
+
+                let in_endpoints = self
+                    .allocator
+                    .endpoints_in
+                    .iter()
+                    .flatten()
+                    .map(|ep| ep.address().index());
+
+                let mut iep: u16 = 0;
+
+                for epnum in in_endpoints {
+                    let ep_regs = regs.endpoint_in(epnum);
+
+                    // filter out non-isochronous endpoints
+                    if read_reg!(endpoint_in, ep_regs, DIEPCTL, EPTYP) & 0x11 != 0x01 {
+                        continue;
+                    }
+
+                    // identify incomplete transfers by the presence of the NAK event
+                    // see RM0383 Rev 3 pp 746 description of NAK:
+                    //
+                    // > In case of isochronous IN endpoints the interrupt gets
+                    // > generated when a zero length packet is transmitted due
+                    // > to unavailability of data in the Tx FIFO.
+                    if read_reg!(endpoint_in, ep_regs, DIEPINT) & 1 << 13 == 0 {
+                        continue;
+                    }
+
+                    // Set NAK
+                    modify_reg!(endpoint_in, ep_regs, DIEPCTL, SNAK: 1);
+                    while read_reg!(endpoint_in, ep_regs, DIEPINT, INEPNE) == 0 {}
+
+                    // Disable the endpoint
+                    modify_reg!(endpoint_in, ep_regs, DIEPCTL, SNAK: 1, EPDIS: 1);
+                    while read_reg!(endpoint_in, ep_regs, DIEPINT, EPDISD) == 0 {}
+                    modify_reg!(endpoint_in, ep_regs, DIEPINT, EPDISD: 1);
+                    assert!(read_reg!(endpoint_in, ep_regs, DIEPCTL, EPENA) == 0);
+                    assert!(read_reg!(endpoint_in, ep_regs, DIEPCTL, EPDIS) == 0);
+
+                    // Flush the TX FIFO
+                    modify_reg!(otg_global, regs.global(), GRSTCTL, TXFNUM: epnum as u32, TXFFLSH: 1);
+                    while read_reg!(otg_global, regs.global(), GRSTCTL, TXFFLSH) == 1 {}
+
+                    iep |= 1 << epnum;
+                }
+
+                PollResult::Data {
+                    ep_out: 0,
+                    ep_in_complete: iep,
+                    ep_setup: 0,
+                }
             } else {
                 let mut ep_out = 0;
                 let mut ep_in_complete = 0;
@@ -716,22 +775,6 @@ impl<USB: UsbPeripheral> usb_device::bus::UsbBus for UsbBus<USB> {
                         }
                         _ => {
                             read_reg!(otg_global, regs.global(), GRXSTSP); // pop GRXSTSP
-                        }
-                    }
-
-                    if status == 0x02 {
-                        if let Some(ep) = &self.allocator.endpoints_out[epnum as usize] {
-                            if let EndpointType::Isochronous {
-                                synchronization: _,
-                                usage: _,
-                            } = ep.ep_type()
-                            {
-                                let ep = regs.endpoint_out(epnum as usize);
-                                let odd = read_reg!(endpoint_out, ep, DOEPCTL, EONUM_DPID);
-                                modify_reg!(endpoint_out, ep, DOEPCTL,
-                                    SD0PID_SEVNFRM: odd as u32,
-                                    SODDFRM: !odd as u32);
-                            }
                         }
                     }
 

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -810,21 +810,6 @@ impl<USB: UsbPeripheral> usb_device::bus::UsbBus for UsbBus<USB> {
                         if let Some(ep) = ep {
                             let ep_regs = regs.endpoint_in(ep.address().index());
                             if read_reg!(endpoint_in, ep_regs, DIEPINT, XFRC) != 0 {
-                                if let EndpointType::Isochronous {
-                                    synchronization: _,
-                                    usage: _,
-                                } = ep.ep_type()
-                                {
-                                    let odd = read_reg!(endpoint_in, ep_regs, DIEPCTL, EONUM_DPID);
-                                    #[cfg(feature = "fs")]
-                                    modify_reg!(endpoint_in, ep_regs, DIEPCTL,
-                                        SD0PID_SEVNFRM: odd as u32,
-                                        SODDFRM_SD1PID: !odd as u32);
-                                    #[cfg(feature = "hs")]
-                                    modify_reg!(endpoint_in, ep_regs, DIEPCTL,
-                                            SD0PID_SEVNFRM: odd as u32,
-                                            SODDFRM: !odd as u32);
-                                }
                                 write_reg!(endpoint_in, ep_regs, DIEPINT, XFRC: 1);
                                 ep_in_complete |= 1 << ep.address().index();
                             }

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -708,9 +708,12 @@ impl<USB: UsbPeripheral> usb_device::bus::UsbBus for UsbBus<USB> {
                     // > In case of isochronous IN endpoints the interrupt gets
                     // > generated when a zero length packet is transmitted due
                     // > to unavailability of data in the Tx FIFO.
-                    if read_reg!(endpoint_in, ep_regs, DIEPINT) & 1 << 13 == 0 {
-                        continue;
-                    }
+                    //
+                    // This check is currently disabled because it causes problems
+                    // at least with macOS.
+                    // if read_reg!(endpoint_in, ep_regs, DIEPINT) & 1 << 13 == 0 {
+                    //     continue;
+                    // }
 
                     // Set NAK
                     modify_reg!(endpoint_in, ep_regs, DIEPCTL, SNAK: 1);

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -141,9 +141,6 @@ impl EndpointIn {
             }
         }
 
-        #[cfg(feature = "fs")]
-        write_reg!(endpoint_in, ep, DIEPTSIZ, PKTCNT: 1, XFRSIZ: buf.len() as u32);
-        #[cfg(feature = "hs")]
         write_reg!(endpoint_in, ep, DIEPTSIZ, MCNT: 1, PKTCNT: 1, XFRSIZ: buf.len() as u32);
 
         match self.descriptor.ep_type {

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -1,5 +1,7 @@
 use crate::endpoint_memory::{EndpointBuffer, EndpointBufferState};
-use crate::ral::{endpoint0_out, endpoint_in, endpoint_out, modify_reg, read_reg, write_reg};
+use crate::ral::{
+    endpoint0_out, endpoint_in, endpoint_out, modify_reg, otg_device, read_reg, write_reg,
+};
 use crate::target::{fifo_write, UsbRegisters};
 use crate::transition::EndpointDescriptor;
 use crate::UsbPeripheral;
@@ -90,30 +92,14 @@ impl EndpointIn {
             write_reg!(endpoint_in, regs, DIEPTSIZ, PKTCNT: 0, XFRSIZ: self.descriptor.max_packet_size as u32);
         } else {
             let regs = self.usb.endpoint_in(self.index() as usize);
-            if let EndpointType::Isochronous {
-                synchronization: _,
-                usage: _,
-            } = self.descriptor.ep_type
-            {
-                write_reg!(endpoint_in, regs, DIEPCTL,
-                    SNAK: 1,
-                    USBAEP: 1,
-                    EPTYP: self.descriptor.ep_type.to_bm_attributes() as u32,
-                    SD0PID_SEVNFRM: 1,
-                    TXFNUM: self.index() as u32,
-                    MPSIZ: self.descriptor.max_packet_size as u32,
-                    EONUM_DPID: 0
-                );
-            } else {
-                write_reg!(endpoint_in, regs, DIEPCTL,
-                    SNAK: 1,
-                    USBAEP: 1,
-                    EPTYP: self.descriptor.ep_type.to_bm_attributes() as u32,
-                    SD0PID_SEVNFRM: 1,
-                    TXFNUM: self.index() as u32,
-                    MPSIZ: self.descriptor.max_packet_size as u32
-                );
-            }
+            write_reg!(endpoint_in, regs, DIEPCTL,
+                SNAK: 1,
+                USBAEP: 1,
+                EPTYP: self.descriptor.ep_type.to_bm_attributes() as u32,
+                SD0PID_SEVNFRM: 1,
+                TXFNUM: self.index() as u32,
+                MPSIZ: self.descriptor.max_packet_size as u32
+            );
         }
     }
 
@@ -138,6 +124,7 @@ impl EndpointIn {
 
     pub fn write(&self, buf: &[u8]) -> Result<()> {
         let ep = self.usb.endpoint_in(self.index() as usize);
+        let device = self.usb.device();
         if self.index() != 0 && read_reg!(endpoint_in, ep, DIEPCTL, EPENA) != 0 {
             return Err(UsbError::WouldBlock);
         }
@@ -158,6 +145,26 @@ impl EndpointIn {
         write_reg!(endpoint_in, ep, DIEPTSIZ, PKTCNT: 1, XFRSIZ: buf.len() as u32);
         #[cfg(feature = "hs")]
         write_reg!(endpoint_in, ep, DIEPTSIZ, MCNT: 1, PKTCNT: 1, XFRSIZ: buf.len() as u32);
+
+        match self.descriptor.ep_type {
+            // Isochronous endpoints must set the correct even/odd frame bit to
+            // correspond with the next frame's number.
+            EndpointType::Isochronous { .. } => {
+                // Previous frame number is OTG_DSTS.FNSOF
+                let frame_number = read_reg!(otg_device, device, DSTS, FNSOF);
+                if frame_number & 0x1 == 1 {
+                    // Previous frame number is odd, so upcoming frame is even
+                    modify_reg!(endpoint_in, ep, DIEPCTL, SD0PID_SEVNFRM: 1);
+                } else {
+                    // Previous frame number is even, so upcoming frame is odd
+                    #[cfg(feature = "fs")]
+                    modify_reg!(endpoint_in, ep, DIEPCTL, SODDFRM_SD1PID: 1);
+                    #[cfg(feature = "hs")]
+                    modify_reg!(endpoint_in, ep, DIEPCTL, SODDFRM: 1);
+                }
+            }
+            _ => {}
+        }
 
         modify_reg!(endpoint_in, ep, DIEPCTL, CNAK: 1, EPENA: 1);
 
@@ -198,33 +205,14 @@ impl EndpointOut {
             modify_reg!(endpoint0_out, regs, DOEPCTL0, MPSIZ: mpsiz as u32, EPENA: 1, CNAK: 1);
         } else {
             let regs = self.usb.endpoint_out(self.index() as usize);
-            if let EndpointType::Isochronous {
-                synchronization: _,
-                usage: _,
-            } = self.descriptor.ep_type
-            {
-                write_reg!(endpoint_out, regs, DOEPTSIZ, PKTCNT: 1, XFRSIZ: 0);
-                // let odd = read_reg!(otg_device, self.usb.device(), DSTS, FNSOF) & 0x01 == 1;
-                write_reg!(endpoint_out, regs, DOEPCTL,
-                    //SODDFRM: 1,
-                    SD0PID_SEVNFRM: 1,
-                    CNAK: 1,
-                    EPENA: 1,
-                    USBAEP: 1,
-                    EPTYP: self.descriptor.ep_type.to_bm_attributes() as u32,
-                    MPSIZ: self.descriptor.max_packet_size as u32,
-                    EONUM_DPID: 0
-                );
-            } else {
-                write_reg!(endpoint_out, regs, DOEPCTL,
-                    SD0PID_SEVNFRM: 1,
-                    CNAK: 1,
-                    EPENA: 1,
-                    USBAEP: 1,
-                    EPTYP: self.descriptor.ep_type.to_bm_attributes() as u32,
-                    MPSIZ: self.descriptor.max_packet_size as u32
-                );
-            }
+            write_reg!(endpoint_out, regs, DOEPCTL,
+                SD0PID_SEVNFRM: 1,
+                CNAK: 1,
+                EPENA: 1,
+                USBAEP: 1,
+                EPTYP: self.descriptor.ep_type.to_bm_attributes() as u32,
+                MPSIZ: self.descriptor.max_packet_size as u32
+            );
         }
     }
 
@@ -244,6 +232,26 @@ impl EndpointOut {
     }
 
     pub fn read(&self, buf: &mut [u8]) -> Result<usize> {
+        let ep = self.usb.endpoint_out(self.index() as usize);
+        let device = self.usb.device();
+
+        match self.descriptor.ep_type {
+            // Isochronous endpoints must set the correct even/odd frame bit to
+            // correspond with the next frame's number.
+            EndpointType::Isochronous { .. } => {
+                // Previous frame number is OTG_DSTS.FNSOF
+                let frame_number = read_reg!(otg_device, device, DSTS, FNSOF);
+                if frame_number & 0x1 == 1 {
+                    // Previous frame number is odd, so upcoming frame is even
+                    modify_reg!(endpoint_out, ep, DOEPCTL, SD0PID_SEVNFRM: 1);
+                } else {
+                    // Previous frame number is even, so upcoming frame is odd
+                    modify_reg!(endpoint_out, ep, DOEPCTL, SODDFRM: 1);
+                }
+            }
+            _ => {}
+        }
+
         critical_section::with(|cs| self.buffer.borrow_ref_mut(cs).read_packet(buf))
     }
 


### PR DESCRIPTION
This PR is a follow-up to https://github.com/esp-rs-compat/synopsys-usb-otg/pull/1 and improves compatibility with Windows and macOS. It is based on https://github.com/stm32-rs/synopsys-usb-otg/pull/29 from the original repo which uses an alternative approach to set the odd/even flags and also manages incomplete transfers.